### PR TITLE
Feat : (Global) 자동으로 생성, 수정, 삭제 시간을 설정해주는 JpaAuditing기능 추가 (#13)

### DIFF
--- a/src/main/java/org/example/wowelang_backend/board/domain/Board.java
+++ b/src/main/java/org/example/wowelang_backend/board/domain/Board.java
@@ -1,0 +1,25 @@
+package org.example.wowelang_backend.board.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @Column(name = "board_name")
+    private String boardName;
+
+    @OneToMany(mappedBy = "board")
+    private List<Post> post;
+}

--- a/src/main/java/org/example/wowelang_backend/board/domain/Post.java
+++ b/src/main/java/org/example/wowelang_backend/board/domain/Post.java
@@ -1,0 +1,55 @@
+package org.example.wowelang_backend.board.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.wowelang_backend.User;
+import org.example.wowelang_backend.common.BaseEntity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @Column(name = "reply_cnt")
+    private Long replyCnt = 0L;
+
+    @Column(name = "is_delete")
+    private Boolean isDelete = false;
+
+    private Long views = 0L;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @OneToMany(mappedBy = "post")
+    private List<Reply> reply = new ArrayList<>();
+
+    public Post(String title, String content, Board board, User user ) {
+        this.title = title;
+        this.content = content;
+        this.board = board;
+        this.user = user;
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/board/domain/Reply.java
+++ b/src/main/java/org/example/wowelang_backend/board/domain/Reply.java
@@ -1,0 +1,39 @@
+package org.example.wowelang_backend.board.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.wowelang_backend.User;
+import org.example.wowelang_backend.board.domain.Post;
+import org.example.wowelang_backend.common.BaseEntity;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reply extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reply_id")
+    private Long id;
+
+    private String content;
+
+    @Column(name = "is_delete")
+    private Boolean isDelete;
+
+    private Long child;
+
+    private Long next;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/org/example/wowelang_backend/common/BaseEntity.java
+++ b/src/main/java/org/example/wowelang_backend/common/BaseEntity.java
@@ -1,0 +1,26 @@
+package org.example.wowelang_backend.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column( name = "created_at", columnDefinition = "TIMESTAMP(6)" )
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP(6)")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP(6)")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/org/example/wowelang_backend/common/JpaAuditingConfig.java
+++ b/src/main/java/org/example/wowelang_backend/common/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.example.wowelang_backend.common;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}


### PR DESCRIPTION
### 🌱관련 이슈

#13 

### 📌작업 내용 및 특이사항

게시글, 댓글이 생성되어 DB에 저장될 때 자동으로 생성시간, 수정시간, 삭제시간을 기록해주는 JPAauditing기능을 구현했습니다.
추후 신고 도메인에도 적용할 예정입니다.

### 📝참고사항

참고자료 : https://webcoding-start.tistory.com/53

### 📚기타

