### PR TITLE
Refactor : (Global) develop 브랜치에 merge가 일어나야지만 배포자동화가 실행되도록 변경 (#16)

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -37,6 +37,7 @@ jobs:
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/live_server:latest
 
   deploy:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### 🌱관련 이슈

#16 

### 📌작업 내용 및 특이사항

기존에 actions를 일으키는 트리거가 develop 브랜치에 push 발생 or PR 발생이어서, feature 브랜치에서 작업한 코드를 PR 올리는 순간 배포자동화 과정이 진행되었습니다.

따라서 PR이 발생할 때는 빌드 -> 배포의 과정 중 빌드만 진행되도록 변경했습니다.

### 📝참고사항



### 📚기타


