### PR TITLE
Feat : (Global) ApiResponse 템플릿 작성 (#12)

### DIFF
--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/ApiResponse.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/ApiResponse.java
@@ -1,0 +1,29 @@
+package org.example.wowelang_backend.common.apiPayLoad;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
+import org.example.wowelang_backend.common.apiPayLoad.status.SuccessStatus;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private Boolean isSuccess; // true / false
+    private  int httpStatusCode; // 200, 404 같은 HTTP 코드
+    private String message; // status에 맞는 메세지
+    private T result; // 담겨지는 data들
+
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus.OK.getHttpStatus().value(), SuccessStatus.OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> created(T result) {
+        return new ApiResponse<>(true, SuccessStatus.CREATED.getHttpStatus().value(), SuccessStatus.CREATED.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> onFail(HttpStatus httpStatus, String message, T data) {
+        return new ApiResponse<>(false, httpStatus.value(), message, data);
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/BaseCode.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/BaseCode.java
@@ -1,0 +1,5 @@
+package org.example.wowelang_backend.common.apiPayLoad;
+
+public interface BaseCode {
+    GlobalResponseDTO getGlobalResponse();
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/GlobalResponseDTO.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/GlobalResponseDTO.java
@@ -1,0 +1,21 @@
+package org.example.wowelang_backend.common.apiPayLoad;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GlobalResponseDTO {
+
+    private final Boolean isSuccess;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Builder
+    public GlobalResponseDTO(Boolean isSuccess, HttpStatus httpStatus, String message) {
+        this.isSuccess = isSuccess;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/exception/ExceptionAdvice.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/exception/ExceptionAdvice.java
@@ -1,0 +1,49 @@
+package org.example.wowelang_backend.common.apiPayLoad.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
+import org.example.wowelang_backend.common.apiPayLoad.GlobalResponseDTO;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+// RestController 붙은 클래스들만 에러처리 해준다!
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIlleglArgumentException(IllegalArgumentException e, HttpServletRequest request) {
+        GlobalResponseDTO errorResponseHttpStatus = GlobalResponseDTO.builder()
+                .isSuccess(false)
+                .httpStatus(HttpStatus.BAD_REQUEST)
+                .message(e.getMessage())
+                .build();
+
+        return handleExceptionInternal(e, errorResponseHttpStatus, null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, GlobalResponseDTO globalResponse, HttpHeaders headers, HttpServletRequest httpServletRequest) {
+        WebRequest webRequest = new ServletWebRequest(httpServletRequest);
+        return handleExceptionInternal(e, globalResponse, headers, globalResponse.getHttpStatus(), webRequest);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, GlobalResponseDTO globalResponse, HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFail(globalResponse.getHttpStatus(), globalResponse.getMessage(), null );
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                globalResponse.getHttpStatus(),
+                request
+        );
+    }
+
+
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/exception/GeneralException.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package org.example.wowelang_backend.common.apiPayLoad.exception;
+
+import lombok.Getter;
+import org.example.wowelang_backend.common.apiPayLoad.GlobalResponseDTO;
+import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final ErrorStatus errorStatus;
+
+    public GeneralException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+    }
+
+    public GlobalResponseDTO getErrorStatus() {
+        return this.errorStatus.getGlobalResponse();
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/status/ErrorStatus.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/status/ErrorStatus.java
@@ -1,0 +1,37 @@
+package org.example.wowelang_backend.common.apiPayLoad.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.wowelang_backend.common.apiPayLoad.BaseCode;
+import org.example.wowelang_backend.common.apiPayLoad.GlobalResponseDTO;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseCode {
+
+    // 본인이 담당한 부분에 맞게 에러코드를 작성해주세요
+
+    // 인증관련 에러
+    TOKEN_INVALID(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
+
+    // 게시글 관련 에러
+    POST_NOT_CREATED(HttpStatus.BAD_REQUEST, "제목과 내용을 입력해주세요"),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+
+    //게시판 관련 에러
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시판을 찾을 수 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public GlobalResponseDTO getGlobalResponse() {
+        return GlobalResponseDTO.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/status/SuccessStatus.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/status/SuccessStatus.java
@@ -1,0 +1,27 @@
+package org.example.wowelang_backend.common.apiPayLoad.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.wowelang_backend.common.apiPayLoad.BaseCode;
+import org.example.wowelang_backend.common.apiPayLoad.GlobalResponseDTO;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    OK(HttpStatus.OK, "OK"),
+    CREATED(HttpStatus.CREATED, "CREATED");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public GlobalResponseDTO getGlobalResponse() {
+        return GlobalResponseDTO.builder()
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .message(message)
+                .build();
+    }
+}


### PR DESCRIPTION
### 🌱관련 이슈

#12 

### 📌작업 내용 및 특이사항

Api 응답에 필요한 템플릿을 작성했습니다.

Api호출 성공 시, 200 OK, 201 CREATED 두 상태코드 중 하나를 상황에 맞게 반환합니다.

Api호출 실패 시, 도메인별로 커스텀한 예외들을 400 BAD_REQUEST, 404 NOT_FOUND, 500 INTERNAL_ERORR 등의 상태코드 들과 함께 전송합니다.

ResponseEntityExceptionHandler를 상속받는 ExceptionAdvice 클래스를 만들고, Spring MVC에서 발생한 예외들을 처리합니다.

### 📝참고사항

**각자 맡은 도메인 별 발생하는 에러 문구 ErrorStatus 클래스에 작성 및 필요한 예외처리 ExceptionAdvice 클래스에 커스텀 하기!!!!**

참고자료: https://velog.io/@appti/ResponseEntityExceptionHandler%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC-%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0

### 📚기타