### PR TITLE
Feat : (Domain) 이미지 S3업로드 로직 구현 (#24)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     /*implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.security:spring-security-test")*/
 
+    // aws S3 의존성
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // 파일 압축 의존성
+    implementation 'net.coobird:thumbnailator:0.4.19'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/wowelang_backend/board/controller/PostFileController.java
+++ b/src/main/java/org/example/wowelang_backend/board/controller/PostFileController.java
@@ -1,0 +1,31 @@
+package org.example.wowelang_backend.board.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.example.wowelang_backend.board.dto.PostImageResponseDTO;
+import org.example.wowelang_backend.board.service.FileService;
+import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/file")
+public class PostFileController {
+
+    @Autowired
+    private final FileService fileService;
+
+    public PostFileController(FileService fileService) {
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/upload")
+    public ApiResponse<PostImageResponseDTO> uploadFile(HttpServletRequest request,
+                                                        @RequestParam("filename") String filename,
+                                                        @RequestParam("contentType") String contentType) throws IOException {
+
+        return ApiResponse.onSuccess(fileService.uploadCompressedImage(request.getInputStream(), filename, contentType));
+
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/board/domain/Image.java
+++ b/src/main/java/org/example/wowelang_backend/board/domain/Image.java
@@ -1,0 +1,29 @@
+package org.example.wowelang_backend.board.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.wowelang_backend.common.BaseEntity;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "file_id")
+    private Long id;
+
+    @Column(name = "image_key", unique = true)
+    private String imageKey;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "is_posted")
+    private Boolean isPosted;
+
+
+}

--- a/src/main/java/org/example/wowelang_backend/board/dto/PostImageResponseDTO.java
+++ b/src/main/java/org/example/wowelang_backend/board/dto/PostImageResponseDTO.java
@@ -1,0 +1,12 @@
+package org.example.wowelang_backend.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostImageResponseDTO {
+
+    private String key;
+    private String url;
+}

--- a/src/main/java/org/example/wowelang_backend/board/repository/ImageRepository.java
+++ b/src/main/java/org/example/wowelang_backend/board/repository/ImageRepository.java
@@ -1,0 +1,10 @@
+package org.example.wowelang_backend.board.repository;
+
+import org.example.wowelang_backend.board.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/java/org/example/wowelang_backend/board/service/FileService.java
+++ b/src/main/java/org/example/wowelang_backend/board/service/FileService.java
@@ -1,0 +1,79 @@
+package org.example.wowelang_backend.board.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import net.coobird.thumbnailator.Thumbnails;
+import org.example.wowelang_backend.board.domain.Image;
+import org.example.wowelang_backend.board.dto.PostImageResponseDTO;
+import org.example.wowelang_backend.board.repository.ImageRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+public class FileService {
+
+    @Autowired
+    private final AmazonS3 amazonS3;
+
+    @Autowired
+    private final ImageRepository imageRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public FileService(AmazonS3 amazonS3, ImageRepository imageRepository) {
+        this.amazonS3 = amazonS3;
+        this.imageRepository = imageRepository;
+    }
+
+    @Transactional
+    public PostImageResponseDTO uploadCompressedImage(InputStream inputStream, String filename, String contentType) throws IOException {
+        try {
+            ByteArrayOutputStream compressedOut = new ByteArrayOutputStream();
+
+            Thumbnails.of(inputStream)
+                    .size(1024, 1024)
+                    .outputQuality(1.0)
+                    .outputFormat("jpg")
+                    .toOutputStream(compressedOut);
+
+            byte[] compressedImage = compressedOut.toByteArray();
+            InputStream compressedInputStream = new ByteArrayInputStream(compressedImage);
+
+            String extension = ".jpg";
+            String uuid = UUID.randomUUID().toString();
+            String key = "post-images/" + uuid + "_" + filename + extension;
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(contentType);
+            metadata.setContentLength(compressedImage.length);
+
+            try {
+                amazonS3.putObject(new PutObjectRequest(bucket, key, compressedInputStream, metadata));
+            } catch (Exception e) {
+                throw new RuntimeException("S3 업로드 중 에러 발생");
+            }
+
+            String url = amazonS3.getUrl(bucket, key).toString();
+
+            imageRepository.save(Image.builder()
+                    .imageKey(key)
+                    .imageUrl(url)
+                    .isPosted(false)
+                    .build());
+
+            return new PostImageResponseDTO(key, url);
+        } catch (Exception e) {
+            throw new RuntimeException("이미지 업로드 중 에러 발생");
+        }
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/common/config/S3Config.java
+++ b/src/main/java/org/example/wowelang_backend/common/config/S3Config.java
@@ -1,0 +1,33 @@
+package org.example.wowelang_backend.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+
+        final BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/org/example/wowelang_backend/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/wowelang_backend/common/config/SecurityConfig.java
@@ -1,0 +1,8 @@
+package org.example.wowelang_backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+
+}

--- a/src/main/java/org/example/wowelang_backend/common/config/WebMvcConfig.java
+++ b/src/main/java/org/example/wowelang_backend/common/config/WebMvcConfig.java
@@ -1,4 +1,4 @@
-package org.example.wowelang_backend.common.configs;
+package org.example.wowelang_backend.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/src/main/java/org/example/wowelang_backend/common/configs/SecurityConfigs.java
+++ b/src/main/java/org/example/wowelang_backend/common/configs/SecurityConfigs.java
@@ -1,8 +1,0 @@
-package org.example.wowelang_backend.common.configs;
-
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class SecurityConfigs {
-
-}


### PR DESCRIPTION
### 🌱관련 이슈
#24 

### 📌작업 내용 및 특이사항
- S3 이미지 업로드 로직을 구현했습니다.
- 3MB 이상의 이미지가 전송될 경우 압축 후 S3로 업로드 합니다. (프론트에서 분기 처리) 
- 업로드 확장자로 png보다 jpg선택한 이유 : jpg가 파일 크기가 더 작음 (용량 작게 처리 가능)
- Stream 업로드 방식을 이용했습니다.
  - 이는 InputStream을 이용하여 S3로 다이렉트로 전송하는 방식으로, 서버의 리소스를 거의 사용하지 않습니다. (소량의 버퍼만 사용)
  - 그러나 업로드할 파일의 용량이 커질수록 업로드 시간이 기하급수적으로 늘어납니다. 
  - 압축을 통해 6.8MB -> 680KB로 변환 했지만 현재 6.8MB의 파일 전송시간에 대략 8초 소요 -> 유저의 사용성 감소
  - 그럼에도 이 방식을 택한 이유는 우리가 배포하는 ec2인스턴스 리소스의 한계 때문입니다. - 프리티어
  - dev서버 배포 이후, 부하테스트를 통해 서버의 리소스를 얼마나 소모하는지 확인 후, 업로드 방식을 개선해 나갈 예정입니다. (PresignedUrl 방식 등)
### 📝참고사항
https://techblog.woowahan.com/11392/

### 📚기타