### PR TITLE
Fix : (Global) 서버 헬스 체크, 스웨거 접근 시 인증이 필요한 문제 해결

### DIFF
--- a/src/main/java/org/example/wowelang_backend/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/wowelang_backend/common/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/user/*/complete").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/user/*/email-verification").permitAll()
+                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/env", "/hc").permitAll()
                         // 이 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
🌱관련 이슈
X

📌작업 내용 및 특이사항
- /hc,  /env,  /swagger-ui/**  접근 시 인증이 필요한 문제 발생
- 시큐리티 설정을 통해 위 api들은 인증 없이 호출가능하도록 변경
 
📝참고사항

📚기타