### PR TITLE
[Fix] (Infra) ssl인증에 따른 github actions worlflow 수정

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -105,9 +105,22 @@ jobs:
       - name: Check deploy server URL
         uses: jtalk/url-health-check-action@v3
         with:
-          url: https://${{ secrets.LIVE_SERVER_IP }}:${{env.STOPPED_PORT}}/env
-          max-attempts: 5
-          retry-delay: 10s
+          username: ubuntu
+          host: ${{ secrets.LIVE_SERVER_IP }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            for i in {1..5}; do
+                    STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${{env.STOPPED_PORT}}/env)
+                    if [ "$STATUS" = "200" ]; then
+                      echo "Health check passed"
+                      exit 0
+                    else
+                      echo "Waiting for app to be ready... ($i/5)"
+                      sleep 10
+                    fi
+                  done
+                  echo "Health check failed"
+                  exit 1
 
       - name: Change nginx upstream
         uses: appleboy/ssh-action@master

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - name: Set target IP
         run: |
-          STATUS=$(curl -o /dev/null -w "%{http_code}" "http://${{ secrets.LIVE_SERVER_IP }}/env")
+          STATUS=$(curl -k -o /dev/null -w "%{http_code}" "https://${{ secrets.LIVE_SERVER_IP }}/env")
           echo $STATUS
           if [ $STATUS = 200 ]; then
-            CURRENT_UPSTREAM=$(curl -s "http://${{ secrets.LIVE_SERVER_IP }}/env")
+            CURRENT_UPSTREAM=$(curl -ks "https://${{ secrets.LIVE_SERVER_IP }}/env")
           else
             CURRENT_UPSTREAM=green
           fi
@@ -105,7 +105,7 @@ jobs:
       - name: Check deploy server URL
         uses: jtalk/url-health-check-action@v3
         with:
-          url: http://${{ secrets.LIVE_SERVER_IP }}:${{env.STOPPED_PORT}}/env
+          url: https://${{ secrets.LIVE_SERVER_IP }}:${{env.STOPPED_PORT}}/env
           max-attempts: 5
           retry-delay: 10s
 


### PR DESCRIPTION
### as - is
- 외부에서 http:<IP주소>:80으로 리버스 프록시 (nginx) 접속 가능
- 외부에서 http:<IP주소>:8080, 8081 으로 리버스 프록시로 가려져야 하는 서버 컨테이너까지 접속 가능

### to - be
- 외부에서 http:<IP주소>:80으로 접속 시 https:<IP주소>:443으로 리다이렉트
- 외부에서 http<IP주소>:8080, 8081로 접속 불가
- 따라서 actions workflow에서 서버 헬스체크를 위해 외부에서 접근하던 로직을 변경해 ssh 접속 후 서버 내부에서 체크하도록 변경