### PR TITLE
[Feat] : (Domain) 인증 - 리프레시 토큰을 RTR방식으로 도입, 인증, 시큐리티 로직 리팩토링, 로그아웃 api 추가

### DIFF
--- a/src/main/java/org/example/wowelang_backend/auth/controller/AuthController.java
+++ b/src/main/java/org/example/wowelang_backend/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.example.wowelang_backend.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.auth.dto.LoginRequestDto;
@@ -15,9 +16,9 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     // @return ApiResponse에 래핑된 JWT 토큰
+    @Operation(summary = "로그인 API", description = "로그인 시 리프레시 토큰과 액세스 토큰 반환", tags = "인증")
     @PostMapping("/login")
     public ApiResponse<JwtDto> login(@RequestBody LoginRequestDto requestDto) {
 
@@ -27,6 +28,8 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
+    @Operation(summary = "AccessToken, RefreshToken 재발급 API", description = "만료된 AccessToken과 RefreshToken 투입 -> 새로운 AccessToken과 새로운 RefreshToken 생성해 전달 (RTR방식) \n"
+    + "리프레시 토큰이 만료되면 로그아웃", tags = "인증")
     public ApiResponse<JwtDto> reIssueAccessToken(
         @RequestHeader("RefreshToken") String refreshToken,
         @RequestHeader("Authorization") String expiredAccessTokenHeader) {
@@ -36,5 +39,14 @@ public class AuthController {
         return ApiResponse.onSuccess(jwtDto);
     }
 
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "RefreshToken을 유효시간을 만료시켜 로그아웃 진행", tags = "인증")
+    public ApiResponse<Void> logout(
+        @RequestHeader ("RefreshToken") String refreshToken) {
+
+        authService.logout(refreshToken);
+
+        return ApiResponse.onSuccess(null);
+    }
 
 }

--- a/src/main/java/org/example/wowelang_backend/auth/controller/AuthController.java
+++ b/src/main/java/org/example/wowelang_backend/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package org.example.wowelang_backend.auth.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.auth.dto.LoginRequestDto;
-import org.example.wowelang_backend.auth.dto.LoginResponseDto;
+import org.example.wowelang_backend.auth.dto.JwtDto;
 import org.example.wowelang_backend.auth.service.AuthService;
 import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
+import org.example.wowelang_backend.security.jwt.JwtTokenProvider;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,12 +15,25 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // @return ApiResponse에 래핑된 JWT 토큰
     @PostMapping("/login")
-    public ApiResponse<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto) {
-        LoginResponseDto loginResponseDto = authService.login(requestDto);
-        return ApiResponse.onSuccess(loginResponseDto);
+    public ApiResponse<JwtDto> login(@RequestBody LoginRequestDto requestDto) {
+
+        JwtDto jwtDto = authService.login(requestDto);
+
+        return ApiResponse.onSuccess(jwtDto);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<JwtDto> reIssueAccessToken(
+        @RequestHeader("RefreshToken") String refreshToken,
+        @RequestHeader("Authorization") String expiredAccessTokenHeader) {
+
+        JwtDto jwtDto = authService.reIssueAccessToken(refreshToken, expiredAccessTokenHeader);
+
+        return ApiResponse.onSuccess(jwtDto);
     }
 
 

--- a/src/main/java/org/example/wowelang_backend/auth/controller/AuthController.java
+++ b/src/main/java/org/example/wowelang_backend/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package org.example.wowelang_backend.auth.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.auth.dto.LoginRequestDto;
+import org.example.wowelang_backend.auth.dto.LoginResponseDto;
 import org.example.wowelang_backend.auth.service.AuthService;
 import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
 import org.springframework.web.bind.annotation.*;
@@ -15,8 +16,10 @@ public class AuthController {
 
     // @return ApiResponse에 래핑된 JWT 토큰
     @PostMapping("/login")
-    public ApiResponse<String> login(@RequestBody LoginRequestDto requestDto) {
-        String token = authService.login(requestDto);
-        return ApiResponse.onSuccess(token);
+    public ApiResponse<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto) {
+        LoginResponseDto loginResponseDto = authService.login(requestDto);
+        return ApiResponse.onSuccess(loginResponseDto);
     }
+
+
 }

--- a/src/main/java/org/example/wowelang_backend/auth/dto/JwtDto.java
+++ b/src/main/java/org/example/wowelang_backend/auth/dto/JwtDto.java
@@ -1,14 +1,15 @@
 package org.example.wowelang_backend.auth.dto;
 
-import lombok.Data;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
 @AllArgsConstructor
-public class LoginResponseDto {
+public class JwtDto {
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/org/example/wowelang_backend/auth/dto/LoginResponseDto.java
+++ b/src/main/java/org/example/wowelang_backend/auth/dto/LoginResponseDto.java
@@ -9,5 +9,6 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class LoginResponseDto {
-    private String token;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/org/example/wowelang_backend/auth/dto/UserPrincipalDTO.java
+++ b/src/main/java/org/example/wowelang_backend/auth/dto/UserPrincipalDTO.java
@@ -1,0 +1,25 @@
+package org.example.wowelang_backend.auth.dto;
+
+import java.security.Principal;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserPrincipalDTO implements Principal {
+
+	private Long id;
+
+	private String loginId;
+
+	List<String> roles;
+
+	@Override
+	public String getName() {
+		return loginId;
+	}
+}

--- a/src/main/java/org/example/wowelang_backend/auth/service/AuthService.java
+++ b/src/main/java/org/example/wowelang_backend/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package org.example.wowelang_backend.auth.service;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.auth.dto.LoginRequestDto;
@@ -18,9 +16,11 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.security.Security;
 import java.util.List;
 
 @Service
@@ -77,8 +77,13 @@ public class AuthService {
 
         // 유저의 리프레시 토큰과 db의 리프레시 토큰 대조
         RefreshToken refreshTokenObj = refreshTokenRepository.findByRefreshToken(refreshToken)
-            .filter(refresh -> !refresh.isExpired() && !refresh.isRevoked())
-            .orElseThrow(() -> new ResponseStatusException(ErrorStatus.TOKEN_INVALID.getHttpStatus(), ErrorStatus.TOKEN_INVALID.getMessage()));
+            .orElseThrow(this::unauthorized);
+
+        // 2-1) 만료 or 이미 삭제된 토큰 ⇒ 로그아웃
+        if (refreshTokenObj.isExpired() || refreshTokenObj.isRevoked()) {
+            refreshTokenObj.revokeRefreshToken();          // 논리 삭제
+            throw unauthorized();
+        }
 
         // 액세스 토큰의 유저아이디와 리프레시 토큰이 참조하는 유저아이디가 같은 지 확인
         String accessTokenUserId = jwtTokenProvider.getUserId(expiredAccessToken);
@@ -109,5 +114,24 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getLoginId(), roles);
 
         return new JwtDto(newAccessToken, newRefreshToken);
+    }
+
+    // 공통 401 반환
+    private ResponseStatusException unauthorized() {
+        return new ResponseStatusException(
+            ErrorStatus.TOKEN_INVALID.getHttpStatus(),
+            ErrorStatus.TOKEN_INVALID.getMessage());
+    }
+
+    @Transactional
+    public void logout(String refreshToken) {
+
+        // DB에서 리프레시 토큰 찾아와서 논리삭제
+        refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(RefreshToken::revokeRefreshToken);
+
+        // TODO : 블랙리스트 방식은 고려사항 (급한건 아님)
+
+        // SecurityContext 비우기
+        SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/org/example/wowelang_backend/auth/service/AuthService.java
+++ b/src/main/java/org/example/wowelang_backend/auth/service/AuthService.java
@@ -1,18 +1,25 @@
 package org.example.wowelang_backend.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.auth.dto.LoginRequestDto;
-import org.example.wowelang_backend.auth.dto.LoginResponseDto;
+import org.example.wowelang_backend.auth.dto.JwtDto;
 import org.example.wowelang_backend.auth.dto.UserPrincipalDTO;
+import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
 import org.example.wowelang_backend.security.custom.CustomUserDetails;
 import org.example.wowelang_backend.security.jwt.JwtTokenProvider;
+import org.example.wowelang_backend.security.jwt.RefreshToken;
 import org.example.wowelang_backend.security.jwt.RefreshTokenRepository;
+import org.example.wowelang_backend.user.domain.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -28,12 +35,13 @@ public class AuthService {
     private long refreshTtl;
 
     // 1) 로그인 로직: 아이디 → 인증 → User 엔티티
-    public LoginResponseDto login(LoginRequestDto dto) {
+    public JwtDto login(LoginRequestDto loginRequestDto) {
         Authentication auth;
         auth = authenticationManager.authenticate(
-            new UsernamePasswordAuthenticationToken(dto.getLoginId(), dto.getPassword())
+            new UsernamePasswordAuthenticationToken(loginRequestDto.getLoginId(), loginRequestDto.getPassword())
         );
 
+        // 유저 Id, 로그인 Id, 역할을 담은 유저 디테일 -> 토큰 생성 시 필요
         CustomUserDetails cd = (CustomUserDetails) auth.getPrincipal();
         Long userId    = cd.getId();
         String loginId = cd.getUsername();
@@ -41,16 +49,65 @@ public class AuthService {
                 .map(GrantedAuthority::getAuthority)
                 .toList();
 
+        // 액세스 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(userId, loginId, roles);
 
+        // 유저 Principal생성
         UserPrincipalDTO userPrincipalDTO = UserPrincipalDTO.builder()
             .id(userId)
             .loginId(loginId)
             .roles(roles)
             .build();
 
+        // 리프레시 토큰 생성
         String refreshToken = jwtTokenProvider.createRefreshToken(userPrincipalDTO ,refreshTtl);
 
-        return new LoginResponseDto(accessToken, refreshToken);
+        return new JwtDto(accessToken, refreshToken);
+    }
+
+    // 액세스 토큰 만료 시 액세스 토큰, 리프레시 토큰 모두 재발행 (RTR 방식)
+    @Transactional
+    public JwtDto reIssueAccessToken(String refreshToken, String expiredAccessTokenHeader) {
+
+        // 헤더에서 액세스 토큰 추출
+        String expiredAccessToken = jwtTokenProvider.extractAccessToken(expiredAccessTokenHeader);
+
+        // 액세스 토큰 밸리데이션 체크
+        jwtTokenProvider.validateAccessToken(expiredAccessToken);
+
+        // 유저의 리프레시 토큰과 db의 리프레시 토큰 대조
+        RefreshToken refreshTokenObj = refreshTokenRepository.findByRefreshToken(refreshToken)
+            .filter(refresh -> !refresh.isExpired() && !refresh.isRevoked())
+            .orElseThrow(() -> new ResponseStatusException(ErrorStatus.TOKEN_INVALID.getHttpStatus(), ErrorStatus.TOKEN_INVALID.getMessage()));
+
+        // 액세스 토큰의 유저아이디와 리프레시 토큰이 참조하는 유저아이디가 같은 지 확인
+        String accessTokenUserId = jwtTokenProvider.getUserId(expiredAccessToken);
+        if(!accessTokenUserId.equals(String.valueOf(refreshTokenObj.getUser().getId()))) {
+            throw new ResponseStatusException(
+                ErrorStatus.TOKEN_INVALID.getHttpStatus(),
+                ErrorStatus.TOKEN_INVALID.getMessage()
+            );
+        }
+
+        // 유저 엔티티 생성 후 Principal 생성
+        User user = refreshTokenObj.getUser();
+        List<String> roles = List.of("ROLE_" + user.getUsertype());
+
+        UserPrincipalDTO userPrincipalDTO = UserPrincipalDTO.builder()
+            .id(user.getId())
+            .loginId(user.getLoginId())
+            .roles(roles)
+            .build();
+
+        // 리프레시 토큰 삭제(논리)
+        refreshTokenObj.revokeRefreshToken();
+
+        // 새로운 리프레시 토큰 생성 (RTR 방식)
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userPrincipalDTO ,refreshTtl);
+
+        // 새로운 액세스 토큰 생성
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getLoginId(), roles);
+
+        return new JwtDto(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/org/example/wowelang_backend/auth/service/AuthService.java
+++ b/src/main/java/org/example/wowelang_backend/auth/service/AuthService.java
@@ -2,16 +2,17 @@ package org.example.wowelang_backend.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.auth.dto.LoginRequestDto;
-import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
+import org.example.wowelang_backend.auth.dto.LoginResponseDto;
+import org.example.wowelang_backend.auth.dto.UserPrincipalDTO;
 import org.example.wowelang_backend.security.custom.CustomUserDetails;
 import org.example.wowelang_backend.security.jwt.JwtTokenProvider;
+import org.example.wowelang_backend.security.jwt.RefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -21,20 +22,17 @@ public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private long refreshTtl;
 
     // 1) 로그인 로직: 아이디 → 인증 → User 엔티티
-    public String login(LoginRequestDto dto) {
+    public LoginResponseDto login(LoginRequestDto dto) {
         Authentication auth;
-        try {
-            auth = authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(dto.getLoginId(), dto.getPassword())
-            );
-        } catch (AuthenticationException ex) {
-            throw new ResponseStatusException(
-                    ErrorStatus.INVALID_USER.getHttpStatus(),
-                    ErrorStatus.INVALID_USER.getMessage()
-            );
-        }
+        auth = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(dto.getLoginId(), dto.getPassword())
+        );
 
         CustomUserDetails cd = (CustomUserDetails) auth.getPrincipal();
         Long userId    = cd.getId();
@@ -43,10 +41,16 @@ public class AuthService {
                 .map(GrantedAuthority::getAuthority)
                 .toList();
 
-        return jwtTokenProvider.createToken(
-                String.valueOf(userId),
-                loginId,
-                roles
-        );
+        String accessToken = jwtTokenProvider.createAccessToken(userId, loginId, roles);
+
+        UserPrincipalDTO userPrincipalDTO = UserPrincipalDTO.builder()
+            .id(userId)
+            .loginId(loginId)
+            .roles(roles)
+            .build();
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(userPrincipalDTO ,refreshTtl);
+
+        return new LoginResponseDto(accessToken, refreshToken);
     }
 }

--- a/src/main/java/org/example/wowelang_backend/board/controller/PostController.java
+++ b/src/main/java/org/example/wowelang_backend/board/controller/PostController.java
@@ -2,7 +2,9 @@ package org.example.wowelang_backend.board.controller;
 
 import org.example.wowelang_backend.board.dto.*;
 import org.example.wowelang_backend.board.service.PostService;
+import org.example.wowelang_backend.common.annotation.CurrentUser;
 import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
+import org.example.wowelang_backend.user.domain.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -28,10 +30,11 @@ public class PostController {
     }
 
     @PostMapping("")
-    public ApiResponse<Long> createPost(@RequestParam Long boardId,
-                                        @RequestBody PostCreateDTO postCreateDto) {
+    public ApiResponse<Long> createPost( @CurrentUser User user,
+                                         @RequestParam Long boardId,
+                                         @RequestBody PostCreateDTO postCreateDto) {
 
-        return ApiResponse.created(postService.createPost(boardId, postCreateDto));
+        return ApiResponse.created(postService.createPost(boardId, postCreateDto, user));
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/org/example/wowelang_backend/board/controller/PostController.java
+++ b/src/main/java/org/example/wowelang_backend/board/controller/PostController.java
@@ -12,6 +12,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 @RestController
 @RequestMapping("/post")
 public class PostController {
@@ -30,7 +32,7 @@ public class PostController {
     }
 
     @PostMapping("")
-    public ApiResponse<Long> createPost( @CurrentUser User user,
+    public ApiResponse<Long> createPost( @Parameter(hidden = true) @CurrentUser User user,
                                          @RequestParam Long boardId,
                                          @RequestBody PostCreateDTO postCreateDto) {
 

--- a/src/main/java/org/example/wowelang_backend/board/service/PostService.java
+++ b/src/main/java/org/example/wowelang_backend/board/service/PostService.java
@@ -45,14 +45,10 @@ public class PostService {
     }
 
     @Transactional
-    public Long createPost(Long boardId, PostCreateDTO postCreateDto) {
+    public Long createPost(Long boardId, PostCreateDTO postCreateDto, User user) {
 
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new IllegalArgumentException(BOARD_NOT_FOUND.getMessage()));
-
-        // TODO: 인증 로직과 합친 후 변경 예정
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new IllegalArgumentException(("등록되지 않은 유저입니다.")));
 
         Post post = Post.createPost(postCreateDto, user, board);
 

--- a/src/main/java/org/example/wowelang_backend/common/CurrentUserArgumentResolver.java
+++ b/src/main/java/org/example/wowelang_backend/common/CurrentUserArgumentResolver.java
@@ -1,0 +1,42 @@
+package org.example.wowelang_backend.common;
+
+import org.example.wowelang_backend.common.annotation.CurrentUser;
+import org.example.wowelang_backend.user.domain.User;
+import org.example.wowelang_backend.user.repository.UserRepository;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.getParameterAnnotation(CurrentUser.class) != null
+			&& parameter.getParameterType().equals(User.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if(authentication == null || !authentication.isAuthenticated()) {
+			return null;
+		}
+
+		String loginId = authentication.getName();
+		return userRepository.findByLoginId(loginId).orElse(null);
+	}
+}

--- a/src/main/java/org/example/wowelang_backend/common/annotation/CurrentUser.java
+++ b/src/main/java/org/example/wowelang_backend/common/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package org.example.wowelang_backend.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/org/example/wowelang_backend/common/apiPayLoad/status/ErrorStatus.java
+++ b/src/main/java/org/example/wowelang_backend/common/apiPayLoad/status/ErrorStatus.java
@@ -54,7 +54,9 @@ public enum ErrorStatus implements BaseCode {
     TOKEN_MALFORMED(HttpStatus.BAD_REQUEST,    "토큰 형식이 올바르지 않습니다."),
     TOKEN_UNSUPPORTED(HttpStatus.BAD_REQUEST, "지원되지 않는 토큰입니다."),
     TOKEN_INVALID(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
-    TOKEN_SIGNATURE_FAILED(HttpStatus.BAD_REQUEST, "토큰 서명 검증에 실패했습니다.");
+    TOKEN_SIGNATURE_FAILED(HttpStatus.BAD_REQUEST, "토큰 서명 검증에 실패했습니다."),
+    TOKEN_NOT_EXISTS(HttpStatus.BAD_REQUEST, "토큰이 존재하지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/example/wowelang_backend/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/wowelang_backend/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.example.wowelang_backend.common.config;
 import lombok.RequiredArgsConstructor;
 import org.example.wowelang_backend.security.jwt.JwtAuthenticationFilter;
 import org.example.wowelang_backend.security.jwt.JwtTokenProvider;
+import org.example.wowelang_backend.security.jwt.RefreshTokenRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -26,6 +27,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -55,7 +57,7 @@ public class SecurityConfig {
                 //JWT 방식으로 들어오는 요청은 “폼 로그인”이 아니라 “헤더에 달린 토큰” 기반으로 인증을 해야 하므로,
                 //폼 로그인 필터가 동작하기 전에 JWT 필터가 먼저 돌면서 인증 여부를 결정하도록 순서를 조정
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        new JwtAuthenticationFilter(jwtTokenProvider, refreshTokenRepository),
                         UsernamePasswordAuthenticationFilter.class
                 );
         return http.build();

--- a/src/main/java/org/example/wowelang_backend/common/config/WebMvcConfig.java
+++ b/src/main/java/org/example/wowelang_backend/common/config/WebMvcConfig.java
@@ -1,11 +1,21 @@
 package org.example.wowelang_backend.common.config;
 
+import java.util.List;
+
+import org.example.wowelang_backend.common.CurrentUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -13,5 +23,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
                 .allowCredentials(true)
                 .maxAge(3000);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
     }
 }

--- a/src/main/java/org/example/wowelang_backend/report/controller/ReportController.java
+++ b/src/main/java/org/example/wowelang_backend/report/controller/ReportController.java
@@ -1,9 +1,13 @@
 package org.example.wowelang_backend.report.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+
+import org.example.wowelang_backend.common.annotation.CurrentUser;
 import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
 import org.example.wowelang_backend.report.dto.ReportCreateDTO;
 import org.example.wowelang_backend.report.service.ReportService;
+import org.example.wowelang_backend.user.domain.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +21,8 @@ public class ReportController {
     private final ReportService reportService;
 
     @PostMapping("")
-    public ApiResponse<Long> createReport(@RequestBody ReportCreateDTO reportCreateDTO) {
+    public ApiResponse<Long> createReport(@Parameter(hidden = true) @CurrentUser User user,  @RequestBody ReportCreateDTO reportCreateDTO) {
 
-        return ApiResponse.created(reportService.createReport(reportCreateDTO));
+        return ApiResponse.created(reportService.createReport(reportCreateDTO, user));
     }
 }

--- a/src/main/java/org/example/wowelang_backend/report/service/ReportService.java
+++ b/src/main/java/org/example/wowelang_backend/report/service/ReportService.java
@@ -22,10 +22,7 @@ public class ReportService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Long createReport(ReportCreateDTO reportCreateDTO) {
-
-        User reportingUser = userRepository.findById(1L)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+    public Long createReport(ReportCreateDTO reportCreateDTO, User user) {
 
         User reportedUser = userRepository.findById(reportCreateDTO.getReportedUserId())
                 .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
@@ -33,7 +30,7 @@ public class ReportService {
         ReportCategory category = reportCategoryRepository.findByReportCategoryName(reportCreateDTO.getReportCategoryName())
                 .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.REPORT_CATEGORY_NOT_FOUND.getMessage()));
 
-        Report report = Report.createReport(reportCreateDTO, reportingUser, reportedUser, category);
+        Report report = Report.createReport(reportCreateDTO, user, reportedUser, category);
 
         reportRepository.save(report);
 

--- a/src/main/java/org/example/wowelang_backend/security/custom/CustomUserDetails.java
+++ b/src/main/java/org/example/wowelang_backend/security/custom/CustomUserDetails.java
@@ -6,8 +6,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
+import lombok.Getter;
+
 public class CustomUserDetails implements UserDetails {
 
+    @Getter
     private final Long id;
     private final String username;
     private final String password;
@@ -21,10 +24,6 @@ public class CustomUserDetails implements UserDetails {
         this.username = username;
         this.password = password;
         this.authorities = authorities;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     @Override

--- a/src/main/java/org/example/wowelang_backend/security/custom/CustomUserDetailsService.java
+++ b/src/main/java/org/example/wowelang_backend/security/custom/CustomUserDetailsService.java
@@ -1,6 +1,8 @@
 package org.example.wowelang_backend.security.custom;
 
 import lombok.RequiredArgsConstructor;
+
+import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
 import org.example.wowelang_backend.user.domain.User;
 import org.example.wowelang_backend.user.repository.UserRepository;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,33 +27,33 @@ public class CustomUserDetailsService implements UserDetailsService {
     // 3) CustomUserDetailsService에서 로그인 아이디 → CustomUserDetails 반환
     @Override
     public UserDetails loadUserByUsername(String loginId) {
-        User u = userRepository.findByLoginId(loginId)
+        User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UsernameNotFoundException(loginId));
         return new CustomUserDetails(
-                u.getId(),
-                u.getLoginId(),
-                u.getPassword(),
-                List.of(new SimpleGrantedAuthority("ROLE_"+u.getUsertype()))
+                user.getId(),
+                user.getLoginId(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_"+user.getUsertype()))
         );
     }
 
     // JWT 필터 등에서 “PK(subject)” 로 로드할 때 쓸 수 있는 별도 메서드
     // 토큰 검증 등 ID(pk)로 바로 조회가 필요할 때 사용하는 메서드
     public CustomUserDetails loadById(Long id) throws UsernameNotFoundException {
-        User u = userRepository.findById(id)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + id));
-        return toCustomUserDetails(u);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UsernameNotFoundException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+        return toCustomUserDetails(user);
     }
 
     // User → CustomUserDetails 변환 공통 로직
-    private CustomUserDetails toCustomUserDetails(User u) {
+    private CustomUserDetails toCustomUserDetails(User user) {
         List<GrantedAuthority> authorities = List.of(
-                new SimpleGrantedAuthority("ROLE_" + u.getUsertype().name())
+                new SimpleGrantedAuthority("ROLE_" + user.getUsertype())
         );
         return new CustomUserDetails(
-                u.getId(),           // PK
-                u.getLoginId(),      // 로그인ID
-                u.getPassword(),     // 암호화된 패스워드
+                user.getId(),           // PK
+                user.getLoginId(),      // 로그인ID
+                user.getPassword(),     // 암호화된 패스워드
                 authorities          // 권한 리스트
         );
     }

--- a/src/main/java/org/example/wowelang_backend/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/JwtAuthenticationFilter.java
@@ -1,22 +1,28 @@
 package org.example.wowelang_backend.security.jwt;
 
 import lombok.RequiredArgsConstructor;
+
+import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
+import org.example.wowelang_backend.user.domain.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     protected void doFilterInternal(
@@ -25,20 +31,47 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         // 1) Authorization 헤더에서 "Bearer {token}" 추출
-        String header = request.getHeader("Authorization");
-        if (header != null && header.startsWith("Bearer ")) {
-            String token = header.substring(7);
+        String accessHeader = checkBearer(request.getHeader("Authorization"));
 
-            // 2) 토큰 유효성 검사
-            if (jwtTokenProvider.validateToken(token)) {
-                // 3) 인증정보를 SecurityContext에 저장
-                Authentication auth = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(auth);
+        if (accessHeader != null && jwtTokenProvider.validateAccessToken(accessHeader)) {
+            setAuth(jwtTokenProvider, accessHeader);
+        } else {
+            String refreshToken = extractRefresh(request);
+            if(refreshToken != null) {
+                reIssue(accessHeader, refreshToken, response);
             }
         }
-
         // 4) 다음 필터 실행
         filterChain.doFilter(request, response);
+    }
+
+    private void reIssue(String oldAccess, String refreshToken, HttpServletResponse response) {
+        RefreshToken refreshTokenObj = refreshTokenRepository.findByRefreshToken(refreshToken)
+            .filter(refresh -> !refresh.isExpired())
+            .orElseThrow(() -> new ResponseStatusException(ErrorStatus.TOKEN_INVALID.getHttpStatus(), ErrorStatus.TOKEN_INVALID.getMessage()));
+
+        User user = refreshTokenObj.getUser();
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getLoginId(),
+                                                                    List.of("ROLE_" + user.getUsertype()));
+
+        response.setHeader("accessToken", newAccessToken);
+
+        setAuth(jwtTokenProvider, newAccessToken);
+    }
+
+    private void setAuth(JwtTokenProvider jwtTokenProvider, String token) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String checkBearer(String header) {
+        return (header != null && header.startsWith("Bearer "))
+            ? header.substring(7) : null;
+    }
+
+    private String extractRefresh(HttpServletRequest request) {
+        return request.getHeader("refreshToken");
     }
 
     @Override

--- a/src/main/java/org/example/wowelang_backend/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/JwtAuthenticationFilter.java
@@ -1,24 +1,20 @@
 package org.example.wowelang_backend.security.jwt;
 
-import jakarta.servlet.http.Cookie;
+
 import lombok.RequiredArgsConstructor;
 
-import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
-import org.example.wowelang_backend.user.domain.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
+
 import java.util.Map;
 import java.util.Set;
 

--- a/src/main/java/org/example/wowelang_backend/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package org.example.wowelang_backend.security.jwt;
 
+import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 
 import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
@@ -7,6 +8,7 @@ import org.example.wowelang_backend.user.domain.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -15,7 +17,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -24,54 +29,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    // 필터에서는 액세스 토큰의 서명만 검증함 (DB 체크 X)
     @Override
     protected void doFilterInternal(
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-        // 1) Authorization 헤더에서 "Bearer {token}" 추출
-        String accessHeader = checkBearer(request.getHeader("Authorization"));
 
-        if (accessHeader != null && jwtTokenProvider.validateAccessToken(accessHeader)) {
-            setAuth(jwtTokenProvider, accessHeader);
-        } else {
-            String refreshToken = extractRefresh(request);
-            if(refreshToken != null) {
-                reIssue(accessHeader, refreshToken, response);
-            }
+        String accessTokenWithBearer = request.getHeader("Authorization");
+
+        String accessToken = jwtTokenProvider.extractAccessToken(accessTokenWithBearer);
+
+        if (jwtTokenProvider.validateAccessToken(accessToken)) {
+            setAuth(jwtTokenProvider, accessToken);
         }
+
         // 4) 다음 필터 실행
         filterChain.doFilter(request, response);
     }
 
-    private void reIssue(String oldAccess, String refreshToken, HttpServletResponse response) {
-        RefreshToken refreshTokenObj = refreshTokenRepository.findByRefreshToken(refreshToken)
-            .filter(refresh -> !refresh.isExpired())
-            .orElseThrow(() -> new ResponseStatusException(ErrorStatus.TOKEN_INVALID.getHttpStatus(), ErrorStatus.TOKEN_INVALID.getMessage()));
-
-        User user = refreshTokenObj.getUser();
-
-        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getLoginId(),
-                                                                    List.of("ROLE_" + user.getUsertype()));
-
-        response.setHeader("accessToken", newAccessToken);
-
-        setAuth(jwtTokenProvider, newAccessToken);
-    }
-
+    // 시큐리티 컨텍스트에 유저정보를 넣어줌
     private void setAuth(JwtTokenProvider jwtTokenProvider, String token) {
         Authentication authentication = jwtTokenProvider.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    private String checkBearer(String header) {
-        return (header != null && header.startsWith("Bearer "))
-            ? header.substring(7) : null;
-    }
-
-    private String extractRefresh(HttpServletRequest request) {
-        return request.getHeader("refreshToken");
     }
 
     @Override
@@ -79,33 +60,38 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         String method = request.getMethod();
 
-        // 토큰 없이도 접근 가능한 엔드포인트
-        // 1) POST /user               (회원가입)
-        if ("/user".equals(path) && "POST".equals(method)) {
-            return true;
-        }
-        // 2) POST /user/check-login-id (아이디 중복 확인)
-        if ("/user/check-login-id".equals(path) && "POST".equals(method)) {
-            return true;
-        }
-        // 3) POST /user/email-verification (메일발송/초기화)
-        if (path.matches("^/user/email-verification$") && "POST".equals(method)) {
-            return true;
-        }
-        // 4) PATCH /user/{id}/complete (코드검증+가입완료)
-        if (path.matches("^/user/complete$") && "PATCH".equals(method)) {
-            return true;
-        }
-        // 5) POST /auth/login         (로그인)
-        if ("/auth/login".equals(path) && "POST".equals(method)) {
-            return true;
-        }
-        // 6) DELETE /user/email-verification (메일발송/초기화)
-        if (path.matches("^/user/email-verification$") && "DELETE".equals(method)) {
-            return true;
+        // 필터를 생략할 URL 패턴 정의
+        Map<String, Set<String>> whitelist = Map.of(
+            "OPTIONS", Set.of("/**"), // CORS Preflight 요청 허용
+            "POST", Set.of(
+                "/user",                       // 회원가입
+                "/user/email-verification",    // 이메일 인증 요청
+                "/user/check-login-id",        // 아이디 중복 체크
+                "/auth/login"                  // 로그인
+            ),
+            "PATCH", Set.of(
+                "/user/complete"               // 가입 완료
+            ),
+            "DELETE", Set.of(
+                "/user/email-verification"     // 이메일 인증 초기화
+            )
+        );
+
+        // Swagger 및 기타 인증 제외 경로
+        Set<String> excludedPaths = Set.of(
+            "/", "/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/env", "/hc", "/error"
+        );
+
+        // exclude 경로 매칭
+        for (String excluded : excludedPaths) {
+            if (PATH_MATCHER.match(excluded, path)) return true;
         }
 
-        // 그 외 모든 요청은 JWT 검사 대상
-        return false;
+        // HTTP 메서드별 화이트리스트 매칭
+        return whitelist.getOrDefault(method, Set.of())
+            .stream()
+            .anyMatch(pattern -> PATH_MATCHER.match(pattern, path));
     }
+
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 }

--- a/src/main/java/org/example/wowelang_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/JwtTokenProvider.java
@@ -6,25 +6,23 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 
 import org.example.wowelang_backend.auth.dto.UserPrincipalDTO;
-import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
+
 import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
-import org.example.wowelang_backend.security.custom.CustomUserDetailsService;
+
 import org.example.wowelang_backend.user.domain.User;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Key;
-import java.time.Duration;
+
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
+
 
 @Component
 @RequiredArgsConstructor
@@ -36,7 +34,6 @@ public class JwtTokenProvider {
     // Access Token 유효기간(초단위)
     @Value("${jwt.token-validity-in-seconds}")
     private Long accesstokenValidityInSeconds;
-    @Value("${jwt.refresh-token-validity-in-seconds}")
 
     private final RefreshTokenRepository refreshTokenRepository;
 

--- a/src/main/java/org/example/wowelang_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/JwtTokenProvider.java
@@ -5,21 +5,22 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 
-import org.example.wowelang_backend.auth.dto.LoginResponseDto;
 import org.example.wowelang_backend.auth.dto.UserPrincipalDTO;
+import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
 import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
 import org.example.wowelang_backend.security.custom.CustomUserDetailsService;
 import org.example.wowelang_backend.user.domain.User;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Key;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -34,9 +35,9 @@ public class JwtTokenProvider {
 
     // Access Token 유효기간(초단위)
     @Value("${jwt.token-validity-in-seconds}")
-    private Long tokenValidityInSeconds;
+    private Long accesstokenValidityInSeconds;
+    @Value("${jwt.refresh-token-validity-in-seconds}")
 
-    private final CustomUserDetailsService customUserDetailsService;
     private final RefreshTokenRepository refreshTokenRepository;
 
     // Bean 초기화 시점에, secretKey를 Base64로 인코딩하여 사용
@@ -55,14 +56,11 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-      /*JWT 토큰 생성
-      @param userId 사용자 식별자 (예: user의 id 값)
-      @param roles  사용자 권한 목록 (userType enum 사용)
-      @return 생성된 JWT 토큰 문자열*/
+      /*액세스 토큰 생성*/
     public String createAccessToken(Long userId, String loginId, List<String> roles){
         // 현재 시간과 만료 시간 설정
         Date now = new Date();
-        Date validity = new Date(now.getTime() + tokenValidityInSeconds * 1000);
+        Date validity = new Date(now.getTime() + accesstokenValidityInSeconds * 1000);
 
         // 토큰 빌더를 통해 토큰 생성 및 서명
         return Jwts.builder()
@@ -75,18 +73,46 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    /**
+     * 리프레시 토큰 생성
+     * 리프레시 토큰은 클라이언트와 DB에 모두 저장
+      */
     public String createRefreshToken(UserPrincipalDTO userPrincipalDTO, long refreshTtl) {
 
-        String refreshToken = UUID.randomUUID().toString();
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshTtl);
+
+        String refreshToken = Jwts.builder()
+                .setIssuedAt(now)
+                    .setExpiration(validity)
+                        .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                            .compact();
 
         User user = User.builder()
-                .id(userPrincipalDTO.getId()).build();
+                .id(userPrincipalDTO.getId())
+                    .loginId(userPrincipalDTO.getLoginId()).build();
 
-        refreshTokenRepository.deleteByUser(user);
-
+        // 리프레시 토큰은 db에 저장해둠
+        // TODO : RTR방식을 사용해서 db접근이 꽤나 필요할 것으로 예상하므로 추후 redis와 같은 인메모리 세션을 두는 것을 고려
         refreshTokenRepository.save(RefreshToken.of(user, refreshToken, refreshTtl));
 
         return refreshToken;
+    }
+
+    // 액세스 토큰에서 유저 아이디 꺼내오는 용도
+    public String getUserId(String token) {
+        return Jwts.parser().setSigningKey(getSigningKey())
+            .build().parseClaimsJws(token)
+            .getBody().getSubject();
+    }
+
+    // 헤더에서 액세스 토큰 추출
+    public String extractAccessToken(String accessTokenWithBearer) {
+        if(accessTokenWithBearer ==null || !accessTokenWithBearer.startsWith("Bearer ")) {
+            throw new NullPointerException(ErrorStatus.TOKEN_NOT_EXISTS.getMessage());
+        }
+
+        return accessTokenWithBearer.substring(7);
     }
 
       /*JWT 토큰의 유효성 검증
@@ -144,6 +170,7 @@ public class JwtTokenProvider {
         Long id = Long.valueOf(claims.getSubject());
         String loginId = claims.get("login_id", String.class);
 
+
         @SuppressWarnings("unchecked")
         List<String> roles = claims.get("roles", List.class);
 
@@ -152,6 +179,8 @@ public class JwtTokenProvider {
         List<SimpleGrantedAuthority> authorities = roles.stream()
             .map(SimpleGrantedAuthority::new).toList();
 
+        // 사용자의 정보를 담은 Authentication 객체 반환
+        // 사용자정보(principal, 비밀번호, 권한 순서)
         return new UsernamePasswordAuthenticationToken(userPrincipalDTO, null, authorities);
     }
 

--- a/src/main/java/org/example/wowelang_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/JwtTokenProvider.java
@@ -4,12 +4,18 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+
+import org.example.wowelang_backend.auth.dto.LoginResponseDto;
+import org.example.wowelang_backend.auth.dto.UserPrincipalDTO;
 import org.example.wowelang_backend.common.apiPayLoad.status.ErrorStatus;
-import org.example.wowelang_backend.security.custom.CustomUserDetails;
 import org.example.wowelang_backend.security.custom.CustomUserDetailsService;
+import org.example.wowelang_backend.user.domain.User;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -17,6 +23,7 @@ import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -30,6 +37,7 @@ public class JwtTokenProvider {
     private Long tokenValidityInSeconds;
 
     private final CustomUserDetailsService customUserDetailsService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     // Bean 초기화 시점에, secretKey를 Base64로 인코딩하여 사용
     // JWT 라이브러리에서 요구하는 형식이며, 일관된 형식을 유지하기 위함
@@ -51,14 +59,14 @@ public class JwtTokenProvider {
       @param userId 사용자 식별자 (예: user의 id 값)
       @param roles  사용자 권한 목록 (userType enum 사용)
       @return 생성된 JWT 토큰 문자열*/
-    public String createToken(String userId, String loginId, List<String> roles){
+    public String createAccessToken(Long userId, String loginId, List<String> roles){
         // 현재 시간과 만료 시간 설정
         Date now = new Date();
         Date validity = new Date(now.getTime() + tokenValidityInSeconds * 1000);
 
         // 토큰 빌더를 통해 토큰 생성 및 서명
         return Jwts.builder()
-                .setSubject(userId)
+                .setSubject(String.valueOf(userId))
                 .claim("login_id", loginId)
                 .claim("roles", roles)   //subject 설정
                 .setIssuedAt(now)           // 발행 시간
@@ -67,10 +75,24 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public String createRefreshToken(UserPrincipalDTO userPrincipalDTO, long refreshTtl) {
+
+        String refreshToken = UUID.randomUUID().toString();
+
+        User user = User.builder()
+                .id(userPrincipalDTO.getId()).build();
+
+        refreshTokenRepository.deleteByUser(user);
+
+        refreshTokenRepository.save(RefreshToken.of(user, refreshToken, refreshTtl));
+
+        return refreshToken;
+    }
+
       /*JWT 토큰의 유효성 검증
      * @param token JWT 토큰 문자열
      * @return 유효하면 true, 그렇지 않으면 예외를 던짐*/
-    public boolean validateToken(String token) {
+    public boolean validateAccessToken(String token) {
         try {
             // 토큰의 서명과 만료 시간을 검증합니다.
             Jwts.parser()
@@ -111,41 +133,26 @@ public class JwtTokenProvider {
         }
     }
 
-      /*JWT 토큰에서 사용자 식별자(subject) 추출
-     * @param token JWT 토큰 문자열
-     * @return 토큰 내의 subject (userId)
-     * @throws RuntimeException 토큰이 유효하지 않으면 ErrorStatus.TOKEN_INVALID 메시지를 포함한 예외 발생*/
-    public String getUserId(String token) {
-        try {
-            Claims claims = Jwts.parser()
-                    .setSigningKey(getSigningKey())
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-            return claims.getSubject();
-        } catch (ExpiredJwtException ex) {
-            throw new IllegalArgumentException(ErrorStatus.TOKEN_EXPIRED.getMessage());
-        } catch (MalformedJwtException ex) {
-            throw new IllegalArgumentException(ErrorStatus.TOKEN_MALFORMED.getMessage());
-        } catch (UnsupportedJwtException ex) {
-            throw new IllegalArgumentException(ErrorStatus.TOKEN_UNSUPPORTED.getMessage());
-        } catch (SignatureException ex) {
-            throw new IllegalArgumentException(ErrorStatus.TOKEN_SIGNATURE_FAILED.getMessage());
-        } catch (JwtException | IllegalArgumentException ex) {
-            throw new IllegalArgumentException(ErrorStatus.TOKEN_INVALID.getMessage());
-        }
-    }
-
     // 토큰으로부터 Authentication 객체 생성
-    // 4) 토큰 검증 시에도, subject(userId) → loadById() 로만 조회
-    public Authentication getAuthentication(String token) {
-        // 1) 토큰에서 subject(userId) 꺼내기
-        Long userId = Long.valueOf(getUserId(token));
+    public UsernamePasswordAuthenticationToken getAuthentication(String token) {
+        Claims claims = Jwts.parser()
+            .setSigningKey(getSigningKey())
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
 
-        // 2) CustomUserDetailsService의 loadById() 호출
-        CustomUserDetails cd = customUserDetailsService.loadById(userId);
+        Long id = Long.valueOf(claims.getSubject());
+        String loginId = claims.get("login_id", String.class);
 
-        // 3) Authentication 객체 생성
-        return new UsernamePasswordAuthenticationToken(cd, null, cd.getAuthorities());
+        @SuppressWarnings("unchecked")
+        List<String> roles = claims.get("roles", List.class);
+
+        UserPrincipalDTO userPrincipalDTO = new UserPrincipalDTO(id, loginId, roles);
+
+        List<SimpleGrantedAuthority> authorities = roles.stream()
+            .map(SimpleGrantedAuthority::new).toList();
+
+        return new UsernamePasswordAuthenticationToken(userPrincipalDTO, null, authorities);
     }
+
 }

--- a/src/main/java/org/example/wowelang_backend/security/jwt/RefreshToken.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/RefreshToken.java
@@ -42,16 +42,25 @@ public class RefreshToken extends BaseEntity {
 	@Column(nullable = false, name = "expire_at")
 	private LocalDateTime expireAt;
 
+	@Column(name = "is_revoked")
+	private boolean isRevoked = false;
+
 	public static RefreshToken of(User user, String token, long ttl) {
 		return new RefreshToken(
 			null,
 			token,
 			user,
-			LocalDateTime.now().plusSeconds(ttl)
+			LocalDateTime.now().plusSeconds(ttl),
+			false
 		);
 	}
 
 	public boolean isExpired() {
 		return expireAt.isBefore(LocalDateTime.now());
+	}
+
+	// 리프레시 토큰 철회 (논리삭제) 메서드
+	public void revokeRefreshToken() {
+		this.isRevoked=true;
 	}
 }

--- a/src/main/java/org/example/wowelang_backend/security/jwt/RefreshToken.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/RefreshToken.java
@@ -1,0 +1,57 @@
+package org.example.wowelang_backend.security.jwt;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.example.wowelang_backend.common.BaseEntity;
+import org.example.wowelang_backend.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class RefreshToken extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "refresh_token_id")
+	private Long id;
+
+	@Column(nullable = false, unique = true, length = 64, name = "refresh_token")
+	private String refreshToken;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(nullable = false, name = "expire_at")
+	private LocalDateTime expireAt;
+
+	public static RefreshToken of(User user, String token, long ttl) {
+		return new RefreshToken(
+			null,
+			token,
+			user,
+			LocalDateTime.now().plusSeconds(ttl)
+		);
+	}
+
+	public boolean isExpired() {
+		return expireAt.isBefore(LocalDateTime.now());
+	}
+}

--- a/src/main/java/org/example/wowelang_backend/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/RefreshTokenRepository.java
@@ -4,12 +4,15 @@ import java.util.Optional;
 
 import org.example.wowelang_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
 	Optional<RefreshToken> findByRefreshToken(String token);
-
-	void deleteByUser(User user);
 }

--- a/src/main/java/org/example/wowelang_backend/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package org.example.wowelang_backend.security.jwt;
+
+import java.util.Optional;
+
+import org.example.wowelang_backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+	Optional<RefreshToken> findByRefreshToken(String token);
+
+	void deleteByUser(User user);
+}

--- a/src/main/java/org/example/wowelang_backend/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/org/example/wowelang_backend/security/jwt/RefreshTokenRepository.java
@@ -2,14 +2,11 @@ package org.example.wowelang_backend.security.jwt;
 
 import java.util.Optional;
 
-import org.example.wowelang_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
 import org.springframework.stereotype.Repository;
 
-import jakarta.transaction.Transactional;
+
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {

--- a/src/main/java/org/example/wowelang_backend/user/controller/InterestController.java
+++ b/src/main/java/org/example/wowelang_backend/user/controller/InterestController.java
@@ -1,9 +1,13 @@
 package org.example.wowelang_backend.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+
+import org.example.wowelang_backend.common.annotation.CurrentUser;
 import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
 import org.example.wowelang_backend.security.custom.CustomUserDetails;
+import org.example.wowelang_backend.user.domain.User;
 import org.example.wowelang_backend.user.dto.InterestDto;
 import org.example.wowelang_backend.user.dto.InterestReqDto;
 import org.example.wowelang_backend.user.service.InterestService;
@@ -31,11 +35,11 @@ public class InterestController {
     @PostMapping("/me")
     @Operation(description = "관심사 수정", summary = "관심사 수정")
     public ApiResponse<List<Long>> initMyInterests(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody InterestReqDto dto
             ) {
         List<Long> ids = dto.getInterestIds();
-        interestService.initInterest(me.getId(), ids);
+        interestService.initInterest(user, ids);
         // 생성된 리소스(최초 관심사 리스트)를 result로 담아서 201 반환
         return ApiResponse.created(ids);
     }
@@ -43,11 +47,11 @@ public class InterestController {
     // 관심사 수정
     @PutMapping("/me")
     public ApiResponse<List<Long>> updateMyInterests(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody InterestReqDto dto
     ) {
         List<Long> newIds = dto.getInterestIds();
-        interestService.updateInterests(me.getId(), newIds);
+        interestService.updateInterests(user, newIds);
         return ApiResponse.onSuccess(newIds);
     }
 }

--- a/src/main/java/org/example/wowelang_backend/user/controller/UserController.java
+++ b/src/main/java/org/example/wowelang_backend/user/controller/UserController.java
@@ -1,10 +1,14 @@
 package org.example.wowelang_backend.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
+import org.example.wowelang_backend.common.annotation.CurrentUser;
 import org.example.wowelang_backend.common.apiPayLoad.ApiResponse;
 import org.example.wowelang_backend.security.custom.CustomUserDetails;
+import org.example.wowelang_backend.user.domain.User;
 import org.example.wowelang_backend.user.dto.*;
 import org.example.wowelang_backend.user.service.UserService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -77,11 +81,11 @@ public class UserController {
     @PostMapping("/me/nickname")
     @Operation(description = "최초 로그인 시 닉네임 설정", summary = "닉네임 설정")
     public ApiResponse<Void> initNickname(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody NicknameReqDto dto
     ) {
         String nickname = dto.getNickname();
-        userService.setNickname(me.getId(), nickname);
+        userService.setNickname(user, nickname);
         return ApiResponse.created(null);
     }
 
@@ -89,31 +93,30 @@ public class UserController {
     @PostMapping("/me/character")
     @Operation(description = "최초 로그인 시 아바타 설정", summary = "아바타 설정")
     public ApiResponse<Void> initCharacter(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody CharacterReqDto dto
     ) {
-        userService.setCharacter(me.getId(), dto.getColorId(), dto.getMaskId());
+        userService.setCharacter(user, dto.getColorId(), dto.getMaskId());
         return ApiResponse.created(null);
     }
 
     // 내 프로필 조회
     @GetMapping("/me/profile")
     @Operation(description = "내 정보 조회", summary = "내 정보 조회")
-
     public UserProfileDto getProfile(
-            @AuthenticationPrincipal CustomUserDetails me
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
-        return userService.getMyProfile(me.getId());
+        return userService.getMyProfile(user);
     }
 
     // 닉네임 수정
     @PutMapping("/me/nickname")
     @Operation(description = "닉네임 수정", summary = "닉네임 수정")
     public ApiResponse<String> updateNickname(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody NicknameReqDto dto
     ) {
-        String saved = userService.updateNickname(me.getId(), dto.getNickname());
+        String saved = userService.updateNickname(user, dto.getNickname());
         return ApiResponse.onSuccess(saved);
     }
 
@@ -121,11 +124,11 @@ public class UserController {
     @PutMapping("/me/character")
     @Operation(description = "아바타 수정", summary = "아바타 수정")
     public ApiResponse<CharacterInfoDto> updateCharacter(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody CharacterReqDto dto
     ) {
         CharacterInfoDto responseDto = userService.updateCharacter(
-                me.getId(),
+                user,
                 dto.getColorId(),
                 dto.getMaskId()
         );
@@ -136,11 +139,11 @@ public class UserController {
     @PutMapping("/me/password")
     @Operation(description = "비밀번호 변경", summary = "비밀번호 변경")
     public ApiResponse<Void> changePassword(
-            @AuthenticationPrincipal CustomUserDetails me,
+        @Parameter(hidden = true) @CurrentUser User user,
             @RequestBody ChangePasswordReqDto req
     ) {
         userService.changePassword(
-                me.getId(),
+                user,
                 req.getCurrentPassword(),
                 req.getNewPassword()
         );
@@ -151,9 +154,9 @@ public class UserController {
     @DeleteMapping("/me")
     @Operation(description = "회원탈퇴", summary = "탈퇴")
     public ApiResponse<Object> deleteAccount(
-            @AuthenticationPrincipal CustomUserDetails me
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
-        userService.deleteAccount(me.getId());
+        userService.deleteAccount(user);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/org/example/wowelang_backend/user/domain/User.java
+++ b/src/main/java/org/example/wowelang_backend/user/domain/User.java
@@ -56,10 +56,10 @@ public class User {
     // 초기 관심사 설정 여부 플래그
     private Boolean interestInitialized = false;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, optional = true)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, optional = true, fetch = FetchType.LAZY)
     private KoreanTutorAttribute koreanTutorAttribute;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, optional = true)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, optional = true, fetch = FetchType.LAZY)
     private ForeignTuteeAttribute foreignTuteeAttribute;
 
     public void setInterestsInitialized(boolean interestsInitialized) {

--- a/src/main/java/org/example/wowelang_backend/user/service/InterestService.java
+++ b/src/main/java/org/example/wowelang_backend/user/service/InterestService.java
@@ -28,10 +28,7 @@ public class InterestService {
 
     //최초 관심사 세팅
     //이미 init 되어 있으면 400 예외 발생
-    public void initInterest(Long userId, List<Long> interestIds) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
-
+    public void initInterest(User user, List<Long> interestIds) {
         if (Boolean.TRUE.equals(user.getInterestInitialized())) {
             throw new IllegalStateException(ErrorStatus.INTERESTS_ALREADY_IVITIALIZED.getMessage());
         }
@@ -62,10 +59,7 @@ public class InterestService {
 
 
     //관심사 수정
-    public void updateInterests(Long userId, List<Long> newInterestIds) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
-
+    public void updateInterests(User user, List<Long> newInterestIds) {
         if (!user.getInterestInitialized()) {
             throw new IllegalStateException(ErrorStatus.INTERESTS_NOT_IVITIALIZED.getMessage());
         }
@@ -77,7 +71,7 @@ public class InterestService {
         }
 
         // 2) 기존 관심사 전부 삭제
-        userInterestRepository.deleteByUserId(userId);
+        userInterestRepository.deleteByUserId(user.getId());
 
         // 3) 새 관심사 일괄 저장
         List<UserInterest> links = interests.stream()

--- a/src/main/java/org/example/wowelang_backend/user/service/UserService.java
+++ b/src/main/java/org/example/wowelang_backend/user/service/UserService.java
@@ -6,7 +6,6 @@ import org.example.wowelang_backend.user.domain.*;
 import org.example.wowelang_backend.user.dto.CharacterInfoDto;
 import org.example.wowelang_backend.user.dto.InterestDto;
 import org.example.wowelang_backend.user.dto.UserProfileDto;
-import org.example.wowelang_backend.user.dto.UserSignupReqDto;
 import org.example.wowelang_backend.user.repository.ForeignTuteeRepository;
 import org.example.wowelang_backend.user.repository.KoreanTutorRepository;
 import org.example.wowelang_backend.user.repository.UserInterestRepository;
@@ -131,10 +130,7 @@ public class UserService {
     }
 
     // 최초 닉네임 설정
-    public String setNickname(Long userId, String nickname) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
-
+    public void setNickname(User user, String nickname) {
         //최초 설정 여부 검사
         if (user.isNicknameInitialized()) {
             throw new IllegalStateException(ErrorStatus.INITIALIZED_NICKNAME.getMessage());
@@ -143,13 +139,10 @@ public class UserService {
         user.initNickname(nickname);
         userRepository.save(user);
 
-        return user.getNickname();
     }
 
     // 최초 캐릭터 설정
-    public CharacterInfoDto setCharacter(Long userId, int colorId, int maskId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+    public void setCharacter(User user, int colorId, int maskId) {
 
         //최초 설정 여부 검사
         if (user.isCharacterInitialized()) {
@@ -160,17 +153,15 @@ public class UserService {
         userRepository.save(user);
 
         // 컨트롤러로 보낼 DTO 생성
-        return new CharacterInfoDto(user.getColorId(), user.getMaskId());
+        new CharacterInfoDto(user.getColorId(), user.getMaskId());
     }
 
     // 내 프로필 조회 (PK, 닉네임, 캐릭터, 관심사)
     @Transactional(readOnly = true)
-    public UserProfileDto getMyProfile(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+    public UserProfileDto getMyProfile(User user) {
 
         // 관심사 조회
-        List<InterestDto> interests = userInterestRepository.findAllByUserId(userId).stream()
+        List<InterestDto> interests = userInterestRepository.findAllByUserId(user.getId()).stream()
                 .map(ui -> new InterestDto(ui.getInterest().getId(), ui.getInterest().getName()))
                 .toList();
         // 캐릭터 정보
@@ -200,9 +191,7 @@ public class UserService {
     }
 
     // 닉네임 수정
-    public String updateNickname(Long userId, String newNickname) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
+    public String updateNickname(User user, String newNickname) {
 
         // 단순 setter 로 덮어쓰기
         user.setNickname(newNickname);
@@ -216,10 +205,7 @@ public class UserService {
     }
 
     // 캐릭터 수정 (언제든)
-    public CharacterInfoDto updateCharacter(Long userId, int colorId, int maskId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
-
+    public CharacterInfoDto updateCharacter(User user, int colorId, int maskId) {
         // 단순 setter 로 덮어쓰기
         user.setColorId(colorId);
         user.setMaskId(maskId);
@@ -232,10 +218,7 @@ public class UserService {
     }
 
     //비밀번호 변경
-    public void changePassword(Long userId, String currentPassword, String newPassword) {
-        User user = userRepository.findByIdAndIsDeleteFalse(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.USER_NOT_FOUND.getMessage()));
-
+    public void changePassword(User user, String currentPassword, String newPassword) {
         // 1) 현재 비밀번호 검증
         if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
             throw new IllegalArgumentException(ErrorStatus.INVALID_PASSWORD.getMessage());
@@ -248,11 +231,7 @@ public class UserService {
     }
 
     //회원탈퇴
-    public void deleteAccount(Long userId) {
-        // 1) 실제 DB에서 삭제하지 않고, isDeleted=true 로 마킹
-        User user = userRepository.findByIdAndIsDeleteFalse(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorStatus.INVALID_USER.getMessage()));
-
+    public void deleteAccount(User user) {
         // (선택) 관심사, ForeignTutee, KoreanTutor 등 연관 객체도 논리 삭제를 원하면 각각의 엔티티에 isDeleted 필드를 추가하고 여기서 또 마킹하세요.
         // 만약 완전 삭제가 필요하다면 userInterestRepository.deleteByUserId(userId) 등을 그대로 호출해도 됩니다.
         // 예시: userInterestRepository.deleteByUserId(userId);


### PR DESCRIPTION
## 🌱관련 이슈
- https://github.com/WowELang/wowelang/issues/85

## 📌작업 내용 및 특이사항
### 인증 로직 변경 
- 기존의 토큰 인증 로직은 단일 Jwt로 매 인증 마다 db조회를 통해 유저 검증
  - 이는 db의 부하를 증가시키고, 단일 토큰이기에 보안성이 떨어짐
- 따라서 refreshToken을 도입하여, accessToken으로 필터단에서 인증을 진행하고(db조회 X), accessToken의 유효기간이 끝나면 refreshToken검증을 통해 (db조회) 새로운 accessToken 발급
- 그러나 refreshToken이 탈취당할 경우 해커가 accessToken을 계속 발급 가능
- 이에 RTR 방식을 도입해 accessToken을 새로 발급할 때 refreshToken도 함께 발급함.
- 이는 보안적인 측면에서 이득이 있으나, 그만큼 db조회가 많아진다는 단점이 있음. -> 추후 in memory로 토큰을 관리할 수 있는 방법을 고려할 필요가 있음

### 에노테이션 생성
- @.CurrentUser 애노테이션을 생성
- accessToken으로 필터단에서 기본적인 인증 절차를 진행한 후, 유저의 정보가 필요한 api의 경우, service단에서 db조회를 통해 유저 정보를 가져와야함. 
- 이를 @.CurrentUser 애노테이션을 통해 추상화 하는 작업 수행
- 개발자는 비즈니스 로직에 더욱 집중할 수 있음

### api변경   
- 로그아웃 api 추가 (블랙리스트 방식은 아직 고려 X)
- accessToken, refreshToken을 새로 발급하는 api 추가

### db 수정사항
- RefreshToken 테이블 추가   

## 📝참고사항
https://okky.kr/questions/1510079

## 📚기타